### PR TITLE
Add basic log file detection

### DIFF
--- a/tools/log_generator.py
+++ b/tools/log_generator.py
@@ -16,7 +16,7 @@ from PyQt5.QtCore import (
     pyqtSignal,
 )
 
-GENERATED_LOGFILE = "fake_logfile.txt"
+GENERATED_LOGFILE = "eqlog_fakelogfile.txt"
 
 ZONE_NORTH_QEYNOS = "[Sat Feb 13 01:40:54 2021] You have entered North Qeynos."
 ZONE_QEYNOS_HILLS = "[Sat Feb 13 01:43:20 2021] You have entered Qeynos Hills."


### PR DESCRIPTION
Scan eq log directory for last modified file, and restart log parser
using the new file.

Update log generator to create file using eq log
format eqlog_fakelog.txt.

Still using eq_logfile.txt to define log directory, so make
sure to change this to your directory instead of your log file.  Adds
basic error handling in case this is set incorrectly.